### PR TITLE
Add Needle implemenation for Fn

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -137,6 +137,15 @@ impl Needle for String {
     }
 }
 
+impl<F> Needle for F
+where
+    F: Fn(&str) -> bool,
+{
+    fn is_match(&self, haystack: &str) -> bool {
+        self(haystack)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -281,5 +290,9 @@ mod tests {
         assert!(!dynamic_dispatched_needle(&Regex::new(r"^est").unwrap()));
         assert!(!dynamic_dispatched_needle(&Regex::new(r"Te$").unwrap()));
         assert!(dynamic_dispatched_needle(&Regex::new(r"^T.+t$").unwrap()));
+
+        assert!(dynamic_dispatched_needle(&|s: &str| s == "Test"));
+        assert!(!dynamic_dispatched_needle(&|s: &str| s == "test"));
+        assert!(!dynamic_dispatched_needle(&|s: &str| s == "Te"));
     }
 }


### PR DESCRIPTION
Hi @stevepryde

I encounter a need in `thirtyfour` for OR functionality in `with_attribute`

```rust
           wb
            .query(locator)
            .wait(timeout, timeout / 3)
            .and_enabled()
            .with_attribute("readonly", |s: &str| s == "" || s == "false")
            .first()
            .await?;
```